### PR TITLE
Change `children` to `find`

### DIFF
--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -14,16 +14,16 @@ function convert(html) {
         // @fixme Doesn't support vertical column headings.
         // @todo Try to support badly formated tables.
         var columnHeadings = [];
-        $(table).children('tr').each(function(i, row) {
-            $(row).children('th').each(function(j, cell) {
+        $(table).find('tr').each(function(i, row) {
+            $(row).find('th').each(function(j, cell) {
                 columnHeadings[j] = $(cell).text().trim();
             });
         });
 
         // Fetch each row
-        $(table).children('tr').each(function(i, row) {
+        $(table).find('tr').each(function(i, row) {
             var rowAsJson = {};
-            $(row).children('td').each(function(j, cell) {
+            $(row).find('td').each(function(j, cell) {
                 if (columnHeadings[j]) {
                     rowAsJson[ columnHeadings[j] ] = $(cell).text().trim();
                 } else {


### PR DESCRIPTION
The difference here is `.children` only looks one level down whereas find looks down the whole tree. Some more explanation: http://stackoverflow.com/questions/648004/what-is-fastest-children-or-find-in-jquery

This fix helped my use case where my `tr` elements were within `tbody` and thus weren't first-level children of `table`. Another solution would be to look for `thead` and `tbody` elements and use children on that but we'd have to see a bunch of different table layouts to see if this general fix catches the use cases.
