### PR TITLE
fix: ReferenceError: convert is not defined

### DIFF
--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -2,7 +2,7 @@ var Q = require('q');
 var cheerio = require('cheerio');
 var request = require('request');
 
-exports.convert = function(html) {
+function convert(html) {
   var jsonResponse = [];
   var $ = cheerio.load(html);
 
@@ -40,6 +40,7 @@ exports.convert = function(html) {
   });
   return jsonResponse;
 }
+exports.convert = convert;
 
 exports.convertUrl = function(url, callback) {
   if (typeof(callback) === "function") {


### PR DESCRIPTION
After the re-structure in latest release, `convertUrl` no longer works, because `convert` is not globally available. This is just a quick-and-dirty fix, I'm no node-module-expert so there may be better ways of doing this.