### PR TITLE
Added options to convertUrl

### DIFF
--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -2,7 +2,11 @@ var Q = require('q');
 var cheerio = require('cheerio');
 var request = require('request');
 
-function convert(html) {
+function convert(html, options) {
+  
+  if ( !options.useFirstRowForHeadings )
+    options.useFirstRowForHeadings = false;
+  
   var jsonResponse = [];
   var $ = cheerio.load(html);
 
@@ -12,7 +16,13 @@ function convert(html) {
     // @fixme Doesn't support vertical column headings.
     // @todo Try to support badly formated tables.
     var columnHeadings = [];
-    $(table).find('tr').each(function(i, row) {
+    
+    var trs = $(table).find('tr')[0];
+    
+    if (options.useFirstRowForHeadings)
+      trs = $(trs[0]);
+    
+    trs.each(function(i, row) {
       $(row).find('th').each(function(j, cell) {
         columnHeadings[j] = $(cell).text().trim();
       });

--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -3,6 +3,9 @@ var cheerio = require('cheerio');
 var request = require('request');
 
 function convert(html, options) {
+
+  if ( !options )
+    options = { useFirstRowForHeadings: false };
   
   if ( !options.useFirstRowForHeadings )
     options.useFirstRowForHeadings = false;
@@ -17,7 +20,7 @@ function convert(html, options) {
     // @todo Try to support badly formated tables.
     var columnHeadings = [];
     
-    var trs = $(table).find('tr')[0];
+    var trs = $(table).find('tr');
     
     if (options.useFirstRowForHeadings)
       trs = $(trs[0]);
@@ -31,7 +34,8 @@ function convert(html, options) {
     // Fetch each row
     $(table).find('tr').each(function(i, row) {
       var rowAsJson = {};
-      $(row).find('td').each(function(j, cell) {
+      var rows = options.useFirstRowForHeadings ? $(row).find('td, th') : $(row).find('td');
+      rows.each(function(j, cell) {
         if (columnHeadings[j]) {
           rowAsJson[ columnHeadings[j] ] = $(cell).text().trim();
         } else {
@@ -52,18 +56,18 @@ function convert(html, options) {
 }
 exports.convert = convert;
 
-exports.convertUrl = function(url, callback) {
+exports.convertUrl = function(url, callback, options) {
   if (typeof(callback) === "function") {
     // Use a callback (if passed)
     fetchUrl(url)
     .then(function(html) {
-      callback.call( this, convert(html) );
+      callback.call( this, convert(html, options) );
     });
   } else {
     // If no callback, return a promise
     return fetchUrl(url)
     .then(function(html) {
-      return convert(html);
+      return convert(html, options);
     });
   }
 }


### PR DESCRIPTION
I was trying to use tabletojson to parse data from this url:
https://www.timeanddate.com/holidays/ireland/2017

The table here has vertical `th` elements containing data. I needed to instruct tabletojson to ignore these so I added a simple option for it. 

after the callback, add an `options` object with `useFirstRowForHeadings: true` and tabletojson will only use the first row to scrape the headings