### PR TITLE
Handle duplicate column headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ You'll need to handle things like work out which tables to parse and (in most ca
 
 You might want to use it with a module like 'cheerio' if you want to parse specific tables identified by id or class (i.e. select them with cheerio and pass the HTML of them as a string).
 
+If there are duplicate column headings, subsequent headings are suffixed with a count:
+```
+// Table
+| PLACE | VALUE | PLACE | VALUE |
+|   abc |     1 |   def |     2 |
+
+// Example output
+[{
+  PLACE: 'abc', VALUE: '1',
+  PLACE_2: 'def', VALUE_2: '2',
+}]
+```
+
+
 ## Example usage
 
 ``` javascript

--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -14,7 +14,15 @@ function convert(html) {
     var columnHeadings = [];
     $(table).find('tr').each(function(i, row) {
       $(row).find('th').each(function(j, cell) {
-        columnHeadings[j] = $(cell).text().trim();
+        var value = $(cell).text().trim();
+        var seen = alreadySeen[value];
+        if (seen) {
+          suffix = ++alreadySeen[value];
+          columnHeadings[j] = value + '_' + suffix;
+        } else {
+          alreadySeen[value] = 1;
+          columnHeadings[j] = value;
+        }
       });
     });
 


### PR DESCRIPTION
This PR adds a "_<count>" suffix to each duplicate column header. If there are three columns named "place" for example, the resulting keys would be `'place', 'place_2', 'place_3'`