### PR TITLE
Update to tabletojson.js : Adding An Option

### DIFF
--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -9,6 +9,7 @@ function convert(html, options) {
       stripHtmlFromHeadings: true,
       stripHtmlFromCells: true,
       stripHtml: null,
+      countDuplicateHeadings: true,
   }, options);
   
   if (options.stripHtml === true) {
@@ -44,7 +45,7 @@ function convert(html, options) {
         : $(cell).html().trim();
         
         var seen = alreadySeen[value];
-        if (seen) {
+        if (seen && options.countDuplicateHeadings) {
           suffix = ++alreadySeen[value];
           columnHeadings[j] = value + '_' + suffix;
         } else {


### PR DESCRIPTION
Proposing a new option: countDuplicateHeadings
This option, when set to false, prevents the script from counting duplicate column headings.
This is useful in particular cases, especially when the tables don't have a simple horizontal set of headings and when they are badly structured.