### PR TITLE
Add the possibility to force column name as number instead of as text when first row as header

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If there are duplicate column headings, subsequent headings are suffixed with a 
 ### Options forceIndexAsNumber
 Instead of using column text (that sometime re-order the data), force an index as a number (string number).
 
-```javascript
-// code
+``` javascript
+// Some JSON (Other rows)
 {
   "0": "",
   "1": "Ａ会",
@@ -75,6 +75,7 @@ Instead of using column text (that sometime re-order the data), force an index a
   "5": "Else",
   "6": ""
 }
+// Some JSON (Other rows)
 ```
 
 ## Options, known issues and limitations

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ If there are duplicate column headings, subsequent headings are suffixed with a 
   PLACE_2: 'def', VALUE_2: '2',
 }]
 ```
+### Options forceIndexAsNumber
+Instead of using column text (that sometime re-order the data), force an index as a number (string number).
+
+```javascript
+// code
+{
+  "0": "",
+  "1": "Ａ会",
+  "2": "Ｂ会",
+  "3": "Ｃ会",
+  "4": "Something",
+  "5": "Else",
+  "6": ""
+}
+```
 
 ## Options, known issues and limitations
 

--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -3,6 +3,7 @@ var cheerio = require('cheerio');
 var request = require('request');
 
 function convert(html, options) {
+
   options = Object.assign({
       useFirstRowForHeadings: false,
       stripHtmlFromHeadings: true,

--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -123,6 +123,10 @@ exports.convertUrl = function(url, arg1, arg2) {
 function fetchUrl(url, callback) {
   var deferred = Q.defer();
   request(url, function (error, response, body) {
+    if(error){
+      deferred.reject(error);
+    }
+
     deferred.resolve(body);
   });
   return deferred.promise;

--- a/lib/tabletojson.js
+++ b/lib/tabletojson.js
@@ -3,12 +3,12 @@ var cheerio = require('cheerio');
 var request = require('request');
 
 function convert(html, options) {
-
   options = Object.assign({
       useFirstRowForHeadings: false,
       stripHtmlFromHeadings: true,
       stripHtmlFromCells: true,
       stripHtml: null,
+      forceIndexAsNumber: false,
   }, options);
   
   if (options.stripHtml === true) {
@@ -64,7 +64,7 @@ function convert(html, options) {
           ? $(cell).text().trim()
           : $(cell).html().trim();
 
-        if (columnHeadings[j]) {
+        if (columnHeadings[j] && !options.forceIndexAsNumber) {
           rowAsJson[ columnHeadings[j] ] = content;
         } else {
           rowAsJson[j] = content;
@@ -123,9 +123,6 @@ exports.convertUrl = function(url, arg1, arg2) {
 function fetchUrl(url, callback) {
   var deferred = Q.defer();
   request(url, function (error, response, body) {
-    if(error){
-      deferred.reject(error);
-    }
     deferred.resolve(body);
   });
   return deferred.promise;


### PR DESCRIPTION
I had an issue when I wanted to enforce the index as a number since I got some column confusing name (empty/etc.).

The FirstRowAsHeading enforce the index to be named based on the header text. But it sometime fails and change the orders of the column. 